### PR TITLE
Support Content-Digest header

### DIFF
--- a/ccclient/uploader.go
+++ b/ccclient/uploader.go
@@ -26,6 +26,7 @@ func NewUploader(logger lager.Logger, httpClient *http.Client) Uploader {
 }
 
 const contentMD5Header = "Content-MD5"
+const contentDigestHeader = "Content-Digest"
 
 func (u *uploader) Upload(uploadURL *url.URL, filename string, r *http.Request, cancelChan <-chan struct{}) (*http.Response, error) {
 	if r.ContentLength <= 0 {
@@ -39,6 +40,7 @@ func (u *uploader) Upload(uploadURL *url.URL, filename string, r *http.Request, 
 	}
 
 	uploadReq.Header.Set(contentMD5Header, r.Header.Get(contentMD5Header))
+	uploadReq.Header.Set(contentDigestHeader, r.Header.Get(contentDigestHeader))
 	uploadReq.URL = uploadURL
 
 	var rsp *http.Response

--- a/ccclient/uploader_test.go
+++ b/ccclient/uploader_test.go
@@ -88,6 +88,12 @@ var _ = Describe("Uploader", func() {
 					Expect(uploadRequest.Header.Get("Content-MD5")).To(Equal("the-md5"))
 				})
 
+				It("Forwards Content-Digest header onto the upload request", func() {
+					var uploadRequest *http.Request
+					Eventually(uploadRequestChan).Should(Receive(&uploadRequest))
+					Expect(uploadRequest.Header.Get("Content-Digest")).To(Equal("the-digest"))
+				})
+
 				Context("When the upload URL has basic auth credentials", func() {
 					BeforeEach(func() {
 						uploadURL.User = url.UserPassword("bob", "cobb")
@@ -218,6 +224,7 @@ func createValidRequest() *http.Request {
 	Expect(err).NotTo(HaveOccurred())
 
 	request.Header.Set("Content-MD5", "the-md5")
+	request.Header.Set("Content-Digest", "the-digest")
 	request.Body = ioutil.NopCloser(bytes.NewBufferString(""))
 
 	fmt.Fprintf(GinkgoWriter, "Content-length %d\n", request.ContentLength)

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Handlers", func() {
 		incomingRequest, err = http.NewRequest("POST", "", buffer)
 		Expect(err).NotTo(HaveOccurred())
 		incomingRequest.Header.Set("Content-MD5", "the-md5")
+		incomingRequest.Header.Set("Content-Digest", "the-digest")
 
 		fakeCloudController = ghttp.NewServer()
 
@@ -126,6 +127,10 @@ var _ = Describe("Handlers", func() {
 
 			It("forwards the content-md5 header", func() {
 				Expect(uploadedHeaders.Get("Content-MD5")).To(Equal("the-md5"))
+			})
+
+			It("forwards the content-digest header", func() {
+				Expect(uploadedHeaders.Get("Content-Digest")).To(Equal("the-digest"))
 			})
 
 			It("uploads the correct file", func() {
@@ -242,6 +247,10 @@ var _ = Describe("Handlers", func() {
 
 			It("forwards the content-md5 header", func() {
 				Expect(uploadedHeaders.Get("Content-MD5")).To(Equal("the-md5"))
+			})
+
+			It("forwards the content-digest header", func() {
+				Expect(uploadedHeaders.Get("Content-Digest")).To(Equal("the-digest"))
 			})
 		})
 


### PR DESCRIPTION
The (CC) StagingsController now supports both `Content-MD5` and `Content-Digest` headers (see [1]). Both headers should be forwarded.

[1] https://github.com/cloudfoundry/cloud_controller_ng/pull/3558
