### PR TITLE
Stop using deprecated `ioutil` package

### DIFF
--- a/ccclient/fake_cc/fake_cc.go
+++ b/ccclient/fake_cc/fake_cc.go
@@ -2,11 +2,12 @@ package fake_cc
 
 import (
 	"fmt"
-	"github.com/onsi/ginkgo/v2"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"regexp"
 	"sync"
+
+	"github.com/onsi/ginkgo/v2"
 
 	"code.cloudfoundry.org/runtimeschema/cc_messages"
 	. "github.com/onsi/gomega"
@@ -110,7 +111,7 @@ func (f *FakeCC) handleDropletUploadRequest(w http.ResponseWriter, r *http.Reque
 	file, _, err := r.FormFile(key)
 	Expect(err).NotTo(HaveOccurred())
 
-	uploadedBytes, err := ioutil.ReadAll(file)
+	uploadedBytes, err := io.ReadAll(file)
 	Expect(err).NotTo(HaveOccurred())
 
 	re := regexp.MustCompile("/staging/droplets/(.*)/upload")

--- a/ccclient/poller_test.go
+++ b/ccclient/poller_test.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -286,7 +286,7 @@ var _ = Describe("Poller", func() {
 func responseWithBody(body string) *http.Response {
 	return &http.Response{
 		StatusCode: http.StatusOK,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+		Body:       io.NopCloser(bytes.NewBufferString(body)),
 	}
 }
 

--- a/ccclient/uploader.go
+++ b/ccclient/uploader.go
@@ -2,7 +2,7 @@ package ccclient
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -97,7 +97,7 @@ func (u *uploader) do(req *http.Request, cancelChan <-chan struct{}) (*http.Resp
 		return rsp, nil
 	}
 
-	respBody, _ := ioutil.ReadAll(rsp.Body)
+	respBody, _ := io.ReadAll(rsp.Body)
 	rsp.Body.Close()
 	return rsp, fmt.Errorf("status code: %d\n%s", rsp.StatusCode, string(respBody))
 }

--- a/ccclient/uploader_test.go
+++ b/ccclient/uploader_test.go
@@ -3,7 +3,7 @@ package ccclient_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -225,7 +225,7 @@ func createValidRequest() *http.Request {
 
 	request.Header.Set("Content-MD5", "the-md5")
 	request.Header.Set("Content-Digest", "the-digest")
-	request.Body = ioutil.NopCloser(bytes.NewBufferString(""))
+	request.Body = io.NopCloser(bytes.NewBufferString(""))
 
 	fmt.Fprintf(GinkgoWriter, "Content-length %d\n", request.ContentLength)
 
@@ -233,5 +233,5 @@ func createValidRequest() *http.Request {
 }
 
 func responseWithCode(code int) *http.Response {
-	return &http.Response{StatusCode: code, Body: ioutil.NopCloser(bytes.NewBufferString(""))}
+	return &http.Response{StatusCode: code, Body: io.NopCloser(bytes.NewBufferString(""))}
 }

--- a/cmd/cc-uploader/main_test.go
+++ b/cmd/cc-uploader/main_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/http/httptest"
@@ -107,11 +106,11 @@ var _ = Describe("CC Uploader", func() {
 
 	JustBeforeEach(func() {
 		var err error
-		configFile, err = ioutil.TempFile("", "uploader_config")
+		configFile, err = os.CreateTemp("", "uploader_config")
 		Expect(err).NotTo(HaveOccurred())
 		configJson, err := json.Marshal(uploaderConfig)
 		Expect(err).NotTo(HaveOccurred())
-		err = ioutil.WriteFile(configFile.Name(), configJson, 0644)
+		err = os.WriteFile(configFile.Name(), configJson, 0644)
 		Expect(err).NotTo(HaveOccurred())
 		args := []string{
 			"-configPath", configFile.Name(),
@@ -217,7 +216,7 @@ var _ = Describe("CC Uploader", func() {
 					if err != nil {
 						log.Fatalln("Unable to load cert", err)
 					}
-					caCert, err := ioutil.ReadFile(uploaderConfig.CCCACert)
+					caCert, err := os.ReadFile(uploaderConfig.CCCACert)
 					if err != nil {
 						log.Fatal("Unable to open cert", err)
 					}

--- a/config/config.go
+++ b/config/config.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -65,7 +65,7 @@ func DefaultUploaderConfig() UploaderConfig {
 }
 
 func NewUploaderConfig(configPath string) (UploaderConfig, error) {
-	configFile, err := ioutil.ReadFile(configPath)
+	configFile, err := os.ReadFile(configPath)
 	if err != nil {
 		return UploaderConfig{}, err
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,7 +1,6 @@
 package config_test
 
 import (
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -19,7 +18,7 @@ var _ = Describe("Config", func() {
 
 	JustBeforeEach(func() {
 		var err error
-		configFile, err = ioutil.TempFile("", "config.json")
+		configFile, err = os.CreateTemp("", "config.json")
 		Expect(err).NotTo(HaveOccurred())
 		_, err = configFile.Write([]byte(configFileContent))
 		Expect(err).NotTo(HaveOccurred())

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -3,7 +3,7 @@ package handlers_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -83,7 +83,7 @@ var _ = Describe("Handlers", func() {
 					uploadedHeaders = r.Header
 					file, fileHeader, err := r.FormFile(ccclient.FormField)
 					Expect(err).NotTo(HaveOccurred())
-					uploadedBytes, err = ioutil.ReadAll(file)
+					uploadedBytes, err = io.ReadAll(file)
 					Expect(err).NotTo(HaveOccurred())
 					uploadedFileName = fileHeader.Filename
 					Expect(r.ContentLength).To(BeNumerically(">", len(uploadedBytes)))
@@ -192,7 +192,7 @@ var _ = Describe("Handlers", func() {
 			It("responds with the status code from the CC request", func() {
 				Expect(outgoingResponse.Code).To(Equal(http.StatusForbidden))
 
-				data, err := ioutil.ReadAll(outgoingResponse.Body)
+				data, err := io.ReadAll(outgoingResponse.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(data)).To(ContainSubstring(strconv.Itoa(http.StatusForbidden)))
 			})
@@ -210,7 +210,7 @@ var _ = Describe("Handlers", func() {
 					uploadedHeaders = r.Header
 					file, fileHeader, err := r.FormFile(ccclient.FormField)
 					Expect(err).NotTo(HaveOccurred())
-					uploadedBytes, err = ioutil.ReadAll(file)
+					uploadedBytes, err = io.ReadAll(file)
 					Expect(err).NotTo(HaveOccurred())
 					uploadedFileName = fileHeader.Filename
 					Expect(r.ContentLength).To(BeNumerically(">", len(uploadedBytes)))
@@ -280,7 +280,7 @@ var _ = Describe("Handlers", func() {
 			It("responds with the status code from the CC request", func() {
 				Expect(outgoingResponse.Code).To(Equal(http.StatusForbidden))
 
-				data, err := ioutil.ReadAll(outgoingResponse.Body)
+				data, err := io.ReadAll(outgoingResponse.Body)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(string(data)).To(ContainSubstring(strconv.Itoa(http.StatusForbidden)))
 			})


### PR DESCRIPTION
Replaces imports and calls to `ioutil` package with their respective functions in the `os` and `io` standard library