### PR TITLE
More resilient droplet upload

### DIFF
--- a/ccclient/poller.go
+++ b/ccclient/poller.go
@@ -47,6 +47,7 @@ func (p *poller) Poll(fallbackURL *url.URL, res *http.Response, cancelChan <-cha
 
 		switch body.Entity.Status {
 		case JOB_QUEUED, JOB_RUNNING:
+			p.logger.Info("cc-job-queued-or-running", lager.Data{"status": body.Entity.Status})
 		case JOB_FINISHED:
 			p.logger.Info("cc-job-finished")
 			return nil

--- a/cmd/cc-uploader/main.go
+++ b/cmd/cc-uploader/main.go
@@ -102,10 +102,6 @@ func main() {
 		logger.Info("graceful-shutdown-waiting-for-uploads")
 		// Wait for all uploads to finish before shutting down
 		uploadWaitGroup.Wait()
-		// Add a delay to ensure responses are sent to Diego before shutdown
-		extraWait := 30 * time.Second
-		logger.Info("waiting-additional-time-before-shutdown", lager.Data{"duration": extraWait})
-		time.Sleep(extraWait) // Ensure uploader has time to send responses
 		// Gracefully shutdown the HTTP server
 		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Second)
 		defer cancel()

--- a/cmd/cc-uploader/main.go
+++ b/cmd/cc-uploader/main.go
@@ -65,14 +65,6 @@ func main() {
 	signalChan := make(chan os.Signal, 1)
 	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 
-	// Goroutine to log any signal received (without handling non-TERM signals)
-	go func() {
-		allSignals := make(chan os.Signal, 1)
-		signal.Notify(allSignals) // Capture all signals for logging
-		for sig := range allSignals {
-			logger.Info("received-signal", lager.Data{"signal": sig.String()})
-		}
-	}()
 	var nonTLSServer *http.Server
 	tlsServer, tlsRunner := initializeServer(logger, uploaderConfig, true)
 	members := grouper.Members{
@@ -126,7 +118,6 @@ func main() {
 		if err := tlsServer.Shutdown(ctx); err != nil {
 			logger.Error("tls-server-shutdown-failed", err)
 		}
-
 	}
 
 	logger.Info("exited")
@@ -202,9 +193,6 @@ func initializeServer(logger lager.Logger, uploaderConfig config.UploaderConfig,
 			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 		}
 
-		if err != nil {
-			logger.Fatal("failed-loading-tls-config", err)
-		}
 		server = &http.Server{
 			Addr:      uploaderConfig.MutualTLS.ListenAddress,
 			Handler:   ccUploaderHandler,

--- a/cmd/cc-uploader/main.go
+++ b/cmd/cc-uploader/main.go
@@ -89,12 +89,12 @@ func main() {
 	logger.Info("ready")
 
 	select {
-	case err := <-monitor.Wait(): // Handle process failure
+	case err := <-monitor.Wait():
 		if err != nil {
 			logger.Info("exited-with-failure")
 			os.Exit(1)
 		}
-	case sig := <-signalChan: // Handle shutdown signal
+	case sig := <-signalChan:
 		logger.Info("shutdown-signal-received", lager.Data{"signal": sig})
 
 		// Gracefully signal Ifrit monitor to stop processes

--- a/cmd/cc-uploader/main_test.go
+++ b/cmd/cc-uploader/main_test.go
@@ -257,6 +257,22 @@ var _ = Describe("CC Uploader", func() {
 					Expect(len(fakeCC.UploadedDroplets[appGuid])).To(Equal(contentLength))
 				})
 			})
+
+		})
+	})
+	Describe("Signal Handling", func() {
+		It("should handle SIGTERM and start shutdown logic", func() {
+			// Send SIGTERM to the cc-uploader process
+			session.Signal(os.Interrupt)
+
+			// Verify that the process logs the shutdown signal
+			Eventually(session, 5*time.Second).Should(gbytes.Say("shutdown-signal-received"))
+
+			// Verify that the process logs the graceful shutdown message
+			Eventually(session, 5*time.Second).Should(gbytes.Say("graceful-shutdown-waiting-for-uploads"))
+
+			// Ensure the process exits cleanly
+			Eventually(session, 30*time.Second).Should(gexec.Exit(0))
 		})
 	})
 })

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"net/http"
+	"sync"
 
 	"code.cloudfoundry.org/cc-uploader"
 	"code.cloudfoundry.org/cc-uploader/ccclient"
@@ -11,9 +12,9 @@ import (
 	"github.com/tedsuo/rata"
 )
 
-func New(uploader ccclient.Uploader, poller ccclient.Poller, logger lager.Logger) (http.Handler, error) {
+func New(uploader ccclient.Uploader, poller ccclient.Poller, logger lager.Logger, uploadWaitGroup *sync.WaitGroup) (http.Handler, error) {
 	return rata.NewRouter(ccuploader.Routes, rata.Handlers{
-		ccuploader.UploadDropletRoute:        upload_droplet.New(uploader, poller, logger),
+		ccuploader.UploadDropletRoute:        upload_droplet.New(uploader, poller, logger, uploadWaitGroup),
 		ccuploader.UploadBuildArtifactsRoute: upload_build_artifacts.New(uploader, logger),
 	})
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"sync"
 	"time"
 
 	"code.cloudfoundry.org/cc-uploader/ccclient"
@@ -53,8 +54,8 @@ var _ = Describe("Handlers", func() {
 
 		uploader := ccclient.NewUploader(logger, http.DefaultClient)
 		poller := ccclient.NewPoller(logger, http.DefaultClient, 100*time.Millisecond)
-
-		handler, err = handlers.New(uploader, poller, logger)
+		var wg sync.WaitGroup
+		handler, err = handlers.New(uploader, poller, logger, &wg)
 		Expect(err).NotTo(HaveOccurred())
 
 		postStatusCode = http.StatusCreated

--- a/handlers/upload_droplet/upload_droplet.go
+++ b/handlers/upload_droplet/upload_droplet.go
@@ -19,7 +19,7 @@ func New(uploader ccclient.Uploader, poller ccclient.Poller, logger lager.Logger
 		uploader:        uploader,
 		poller:          poller,
 		logger:          logger,
-		uploadWaitGroup: uploadWaitGroup, // Store reference
+		uploadWaitGroup: uploadWaitGroup,
 	}
 }
 
@@ -27,7 +27,7 @@ type dropletUploader struct {
 	uploader        ccclient.Uploader
 	poller          ccclient.Poller
 	logger          lager.Logger
-	uploadWaitGroup *sync.WaitGroup // Add a pointer to WaitGroup
+	uploadWaitGroup *sync.WaitGroup
 }
 
 var MissingCCDropletUploadUriKeyError = errors.New(fmt.Sprintf("missing %s parameter", cc_messages.CcDropletUploadUriKey))

--- a/handlers/upload_droplet/upload_droplet_test.go
+++ b/handlers/upload_droplet/upload_droplet_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"sync"
 	"time"
 
 	"code.cloudfoundry.org/cc-uploader/ccclient/fake_ccclient"
@@ -36,7 +37,8 @@ var _ = Describe("UploadDroplet", func() {
 
 		JustBeforeEach(func() {
 			logger = lager.NewLogger("fake-logger")
-			dropletUploadHandler := upload_droplet.New(&uploader, &poller, logger)
+			var wg sync.WaitGroup
+			dropletUploadHandler := upload_droplet.New(&uploader, &poller, logger, &wg)
 
 			dropletUploadHandler.ServeHTTP(responseWriter, incomingRequest)
 		})


### PR DESCRIPTION
Previously, the cc-uploader process did not have a draining mechanism. When the process was stopped, any ongoing droplet uploads were aborted immediately, leading to potential failures and incomplete uploads.

This PR introduces a graceful shutdown mechanism to allow ongoing uploads to complete before termination. The key enhancements include:  

- **Handling shutdown signals:**  
  - The process now listens for termination signals (`SIGINT`, `SIGTERM`) and responds by allowing uploads to finish before exiting.  
- **Tracking active uploads:**  
  - A global `WaitGroup` (`uploadWaitGroup`) is introduced to track ongoing uploads, incremented when a new droplet upload begins and decremented when it completes. 
- **Graceful waiting before shutdown:**
 Upon receiving a shutdown signal, cc-uploader will:
1 Log the shutdown event.
2 Wait for all active uploads to complete using the uploadWaitGroup.
3 Gracefully shut down the HTTP servers (TLS and non-TLS).
- **Graceful server shutdown:**
Uses http.Server.Shutdown with a timeout to gracefully close both TLS and non-TLS servers.  

### **Code Changes**  
1. **Signal Handling:**  
   - Introduced a `signalChan` to capture termination signals.  
2. **WaitGroup for Uploads:**  
   - `uploadWaitGroup` ensures `cc-uploader` waits for all uploads to finish before stopping.  
4. **Graceful Shutdown Logic:**  
   - The shutdown process now waits for active uploads to complete and cleanly shuts down the HTTP servers.

- Links to any other associated PRs
https://github.com/cloudfoundry/capi-release/pull/529
https://github.com/cloudfoundry/cloud_controller_ng/pull/4296